### PR TITLE
close file descriptors once only

### DIFF
--- a/source/__init__.py
+++ b/source/__init__.py
@@ -112,8 +112,11 @@ Raises:
 	
 	def close(self):
 		"""Close the file descriptor."""
-		try:    os.close(self._fd)
+		try:    
+			if self._fd: os.close(self._fd)
 		except: pass
+		self._fd = None
+
 	
 	
 	def fileno(self):
@@ -242,8 +245,10 @@ Raises:
 	
 	def close(self):
 		"""Close the file descriptor."""
-		try:    os.close(self._fd)
+		try:    
+			if self._fd: os.close(self._fd)
 		except: pass
+		self._fd = None
 	
 	
 	def fileno(self):
@@ -397,8 +402,10 @@ Raises:
 	
 	def close(self):
 		"""Close the file descriptor."""
-		try:    os.close(self._fd)
+		try:    
+			if self._fd: os.close(self._fd)
 		except: pass
+		self._fd = None
 	
 	
 	def fileno(self):
@@ -536,8 +543,11 @@ Raises:
 	
 	def close(self):
 		"""Close the file descriptor."""
-		try:    os.close(self._fd)
+		try:    
+			if self._fd: os.close(self._fd)
 		except: pass
+		self._fd = None
+
 	
 	
 	def fileno(self):


### PR DESCRIPTION
This prevents file descriptors being closed more than once.

Specifically, it prevents a bug where a new `timerfd` is given a file descriptor which previously belonged to another, expired timer.  When the expired (and closed) `timerfd` was garbage collected it wrongly closed the file descriptor again. The new `timerfd` then failed, raising a bad file descriptor error when read.